### PR TITLE
fix: flat-cache doesn't provide default export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepcode/tsc",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepcode/tsc",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Typescript consumer of Deepcode public API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/files.ts
+++ b/src/files.ts
@@ -5,7 +5,7 @@ import micromatch from 'micromatch';
 import crypto, { HexBase64Latin1Encoding } from 'crypto';
 import { union } from 'lodash';
 import util from 'util';
-import flatCache from 'flat-cache';
+import * as flatCache from 'flat-cache';
 
 import { HASH_ALGORITHM, ENCODE_TYPE, MAX_PAYLOAD, IGNORES_DEFAULT, IGNORE_FILES_NAMES, CACHE_KEY } from './constants';
 


### PR DESCRIPTION
flat-cache doesn't provide default export, therefore it was failing a compilation.