### PR TITLE
sent custom oAuthToken as a header, not a query param

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -399,9 +399,9 @@ export async function getAnalysis(options: {
 }): Promise<IResult<GetAnalysisResponseDto, GetAnalysisErrorCodes>> {
   const { baseURL, sessionToken, oAuthToken, bundleId, includeLint, severity } = options;
   // ?linters=false is still a truthy query value, if(includeLint === false) we have to avoid sending the value altogether
-  const params = { severity, linters: includeLint || undefined, oAuthToken };
+  const params = { severity, linters: includeLint || undefined };
   const config: AxiosRequestConfig = {
-    headers: { 'Session-Token': sessionToken },
+    headers: { 'Session-Token': sessionToken, 'Custom-oAuthToken': oAuthToken },
     params,
     url: `${baseURL}${apiPath}/analysis/${bundleId}`,
     method: 'GET',

--- a/src/http.ts
+++ b/src/http.ts
@@ -401,7 +401,7 @@ export async function getAnalysis(options: {
   // ?linters=false is still a truthy query value, if(includeLint === false) we have to avoid sending the value altogether
   const params = { severity, linters: includeLint || undefined };
   const config: AxiosRequestConfig = {
-    headers: { 'Session-Token': sessionToken, 'Custom-oAuthToken': oAuthToken },
+    headers: { 'Session-Token': sessionToken, 'X-OAuthToken': oAuthToken },
     params,
     url: `${baseURL}${apiPath}/analysis/${bundleId}`,
     method: 'GET',


### PR DESCRIPTION
It's better to send security related token as headers, as they will not be logged, unlike querystrings.
This PR depends on https://github.com/DeepCodeAI/product/pull/631