### PR TITLE
Add username param to analyzeGit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.15] - 2020-12-08
+- Add Username param to analyzeGit
+
 ## [2.0.14] - 2020-12-07
 - New fields with timing and file coverage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepcode/tsc",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepcode/tsc",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "Typescript consumer of Deepcode public API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -39,6 +39,7 @@ async function pollAnalysis({
   severity,
   bundleId,
   oAuthToken,
+  username,
 }: {
   baseURL: string;
   sessionToken: string;
@@ -46,6 +47,7 @@ async function pollAnalysis({
   severity: AnalysisSeverity;
   bundleId: string;
   oAuthToken?: string;
+  username?: string;
 }): Promise<IResult<AnalysisFailedResponse | AnalysisFinishedResponse, GetAnalysisErrorCodes>> {
   let analysisResponse: IResult<GetAnalysisResponseDto, GetAnalysisErrorCodes>;
   let analysisData: GetAnalysisResponseDto;
@@ -62,6 +64,7 @@ async function pollAnalysis({
       baseURL,
       sessionToken,
       oAuthToken,
+      username,
       bundleId,
       includeLint,
       severity,
@@ -101,6 +104,7 @@ export async function analyzeBundle({
   severity = AnalysisSeverity.info,
   bundleId,
   oAuthToken,
+  username,
 }: {
   baseURL: string;
   sessionToken: string;
@@ -108,9 +112,10 @@ export async function analyzeBundle({
   severity: AnalysisSeverity;
   bundleId: string;
   oAuthToken?: string;
+  username?: string;
 }): Promise<IBundleResult> {
   // Call remote bundle for analysis results and emit intermediate progress
-  const analysisData = await pollAnalysis({ baseURL, sessionToken, oAuthToken, bundleId, includeLint, severity });
+  const analysisData = await pollAnalysis({ baseURL, sessionToken, oAuthToken, username, bundleId, includeLint, severity });
 
   if (analysisData.type === 'error') {
     throw analysisData.error;
@@ -271,14 +276,15 @@ export async function analyzeGit(
   gitUri: string,
   sarif = false,
   oAuthToken?: string,
+  username?: string,
 ): Promise<IGitBundle> {
-  const bundleResponse = await createGitBundle({ baseURL, sessionToken, oAuthToken, gitUri });
+  const bundleResponse = await createGitBundle({ baseURL, sessionToken, oAuthToken, username, gitUri });
   if (bundleResponse.type === 'error') {
     throw bundleResponse.error;
   }
   const { bundleId } = bundleResponse.value;
 
-  const analysisData = await analyzeBundle({ baseURL, sessionToken, oAuthToken, includeLint, severity, bundleId });
+  const analysisData = await analyzeBundle({ baseURL, sessionToken, oAuthToken, username, includeLint, severity, bundleId });
 
   const result = {
     baseURL,

--- a/src/http.ts
+++ b/src/http.ts
@@ -295,12 +295,16 @@ export async function createGitBundle(options: {
   readonly baseURL: string;
   readonly sessionToken: string;
   readonly oAuthToken?: string;
+  readonly username?: string;
   readonly gitUri: string;
 }): Promise<IResult<RemoteBundle, CreateGitBundleErrorCodes>> {
-  const { baseURL, sessionToken, oAuthToken, gitUri } = options;
+  const { baseURL, sessionToken, oAuthToken, username, gitUri } = options;
   const headers = { 'Session-Token': sessionToken };
   if (oAuthToken) {
     headers['X-OAuthToken'] = oAuthToken;
+  }
+  if (username) {
+    headers['X-UserName'] = username;
   }
   const config: AxiosRequestConfig = {
     headers,
@@ -401,17 +405,21 @@ export async function getAnalysis(options: {
   readonly baseURL: string;
   readonly sessionToken: string;
   readonly oAuthToken?: string;
+  readonly username?: string;
   readonly bundleId: string;
   readonly includeLint?: boolean;
   readonly severity: number;
 }): Promise<IResult<GetAnalysisResponseDto, GetAnalysisErrorCodes>> {
-  const { baseURL, sessionToken, oAuthToken, bundleId, includeLint, severity } = options;
+  const { baseURL, sessionToken, oAuthToken, username, bundleId, includeLint, severity } = options;
   // ?linters=false is still a truthy query value, if(includeLint === false) we have to avoid sending the value altogether
   const params = { severity, linters: includeLint || undefined };
 
   const headers = { 'Session-Token': sessionToken };
   if (oAuthToken) {
     headers['X-OAuthToken'] = oAuthToken;
+  }
+  if (username) {
+    headers['X-UserName'] = username;
   }
   const config: AxiosRequestConfig = {
     headers,


### PR DESCRIPTION
A new `username` param as part of `analyzeGit` to support our `BitBucket Cloud` integration