### PR TITLE
Added markers interfile position

### DIFF
--- a/src/interfaces/analysis-result.interface.ts
+++ b/src/interfaces/analysis-result.interface.ts
@@ -47,9 +47,13 @@ export interface IPosition {
   rows: Point;
 }
 
+export interface IMarkerPosition extends IPosition {
+  file: string;
+}
+
 export interface IMarker {
   msg: Point;
-  pos: IPosition[];
+  pos: IMarkerPosition[];
 }
 
 export interface IFileSuggestion extends IPosition {

--- a/src/sarif_converter.ts
+++ b/src/sarif_converter.ts
@@ -128,7 +128,7 @@ const getResults = (suggestions: ISarifSuggestions) => {
             location: {
               physicalLocation: {
                 artifactLocation: {
-                  uri: suggestion.file,
+                  uri: position.file,
                   uriBaseId: '%SRCROOT%',
                   // index: i,
                 },

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -373,7 +373,8 @@ describe('Requests to public API', () => {
 
       expect(suggestion.tags).toEqual([]);
       expect(Object.keys(response.value.analysisResults.files).length).toEqual(4);
-      expect(response.value.analysisResults.files[`/AnnotatorTest.cpp`]).toEqual({
+      const filePath = `/AnnotatorTest.cpp`;
+      expect(response.value.analysisResults.files[filePath]).toEqual({
         '0': [
           {
             cols: [8, 27],
@@ -391,6 +392,7 @@ describe('Requests to public API', () => {
                   {
                     cols: [7, 14],
                     rows: [8, 8],
+                    file: filePath,
                   },
                 ],
               },
@@ -400,6 +402,7 @@ describe('Requests to public API', () => {
                   {
                     cols: [6, 25],
                     rows: [10, 10],
+                    file: filePath,
                   },
                 ],
               },


### PR DESCRIPTION
This PR depends on https://github.com/DeepCodeAI/product/pull/685

The tests seam to fail locally (to test them, run `DEEPCODE_URL=http://localhost:8080 npm run test`). This is probably due to the `multifile-markers` engine version having a different knowledgebase than usual.

However it also seams we don't have tests for the SARIF formatter, please @Spoor2709 review this as well and try to check the validity of the markers URI.